### PR TITLE
Update test for received invokes method

### DIFF
--- a/spec/issues/23.test.ts
+++ b/spec/issues/23.test.ts
@@ -1,23 +1,23 @@
-import test from 'ava';
+import test from "ava";
 
-import { Substitute, Arg } from '../../src/Index';
+import { Substitute, Arg } from "../../src/Index";
 
 interface CalculatorInterface {
-    add(a: number, b: number): number
-    subtract(a: number, b: number): number
-    divide(a: number, b: number): number
-    isEnabled: boolean
+  add(a: number, b: number): number;
+  subtract(a: number, b: number): number;
+  divide(a: number, b: number): number;
+  isEnabled: boolean;
 }
 
-test('issue 23: mimick received should not call method', t => {
-    const mockedCalculator = Substitute.for<CalculatorInterface>();
+test("issue 23: mimick received should not call method", t => {
+  const mockedCalculator = Substitute.for<CalculatorInterface>();
 
-    let result = 0;
-    mockedCalculator.add(Arg.all()).mimicks((a, b) => {
-        return result = a + b;
-    });
+  mockedCalculator.add(Arg.all()).mimicks((a, b) => {
+    t.deepEqual(a, 1);
+    return a + b;
+  });
 
-    t.throws(() => mockedCalculator.received().add(Arg.any(), Arg.any()));
+  mockedCalculator.add(1, 1); // ok
 
-    t.is(result, 0);
+  mockedCalculator.received(1).add(2, 1); // not ok, calls mimick func
 });


### PR DESCRIPTION
I've updated the test to illustrate issue #23.
I'm not 100% sure how you see the library functioning and I'm not familiar enough with NSubstitute to state how it functions, however for my use case, I need to check that a method has been called **without** invoking it in the check.
The invocation is buried deep within another component I'm testing and I just need to assert that the argument has been transformed correctly within the invocation.

So I've now modified your test to assert that we should only call our mimicked method with `1` as the first argument.

Apologies for the distracting formatting changes :(