### PR TITLE
Change inference order for ObjectSubstituteTransformation. Fixes ffMathy#24.

### DIFF
--- a/spec/issues/24.test.ts
+++ b/spec/issues/24.test.ts
@@ -1,0 +1,22 @@
+import test from 'ava';
+
+import { Substitute } from '../../src/index';
+
+interface IHaveOptionalArguments {
+  onlyOptional(a?: number): number;
+  mandatoryAndOptional(a: number, b?: number): number;
+}
+test('issue 24 - Mocked method arguments not allowed when verifying method was called', async t => {
+  const substitute = Substitute.for<IHaveOptionalArguments>();
+  substitute.onlyOptional().returns(1);
+  substitute.onlyOptional(2).returns(2);
+
+  t.is(substitute.onlyOptional(), 1);
+  t.is(substitute.onlyOptional(2), 2);
+
+  substitute.mandatoryAndOptional(1).returns(1);
+  substitute.mandatoryAndOptional(1, 2).returns(2);
+
+  t.is(substitute.mandatoryAndOptional(1), 1);
+  t.is(substitute.mandatoryAndOptional(1, 2), 2);
+});

--- a/src/Transformations.ts
+++ b/src/Transformations.ts
@@ -36,8 +36,8 @@ type TerminatingObject<T> = {
 
 type ObjectSubstituteTransformation<T extends Object> = {
     [P in keyof T]:
-    T[P] extends () => infer R ? NoArgumentFunctionSubstitute<R> :
     T[P] extends (...args: infer F) => infer R ? FunctionSubstitute<F, R> :
+    T[P] extends () => infer R ? NoArgumentFunctionSubstitute<R> :
     PropertySubstitute<T[P]>;
 }
 


### PR DESCRIPTION
I found this solution to the issue I commented on a few days ago. Just exchanging the cases so that `(...args)` is matched before `()` did the trick.