### PR TITLE
Test case for optional parameters

### DIFF
--- a/spec/issues/59.test.ts
+++ b/spec/issues/59.test.ts
@@ -1,0 +1,17 @@
+import test from 'ava';
+
+import { Substitute } from '../../src/index';
+
+interface IEcho {
+  echo(a: string): string
+  maybeEcho(a?: string): string
+}
+
+test('issue 59 - Mock function with optional parameters', (t) => {
+  const echoer = Substitute.for<IEcho>()
+  echoer.maybeEcho('foo').returns('bar')
+  echoer.maybeEcho().returns('baz')
+
+  t.is(echoer.maybeEcho('foo'), 'bar')
+  t.is(echoer.maybeEcho(), 'baz')
+})


### PR DESCRIPTION
This adds a test case for the case of trying to mock functions with optional parameters.

Good news is that between the last release and now, the fix has been put in place! I was a bit confused as to why my test worked here, so confirmed that the test repo linked from #59 was still broken, used `yarn link` to use the latest source and the tests started passing. 👍 

Closes #59.