### PR TITLE
failing example of received with optional param

### DIFF
--- a/spec/issues/59.test.ts
+++ b/spec/issues/59.test.ts
@@ -13,5 +13,6 @@ test('issue 59 - Mock function with optional parameters', (t) => {
   echoer.maybeEcho().returns('baz')
 
   t.is(echoer.maybeEcho('foo'), 'bar')
+  echoer.received().maybeEcho('foo');
   t.is(echoer.maybeEcho(), 'baz')
 })

--- a/src/Transformations.ts
+++ b/src/Transformations.ts
@@ -29,7 +29,7 @@ export type ObjectSubstitute<T extends Object, K extends Object = T> = ObjectSub
 
 type TerminatingObject<T> = {
     [P in keyof T]:
-    // T[P] extends () => infer R ? () => void :
+    T[P] extends () => infer R ? () => void :
     T[P] extends (...args: infer F) => infer R ? (...args: F) => void : 
     T[P];
 }

--- a/src/Transformations.ts
+++ b/src/Transformations.ts
@@ -29,7 +29,7 @@ export type ObjectSubstitute<T extends Object, K extends Object = T> = ObjectSub
 
 type TerminatingObject<T> = {
     [P in keyof T]:
-    T[P] extends () => infer R ? () => void :
+    // T[P] extends () => infer R ? () => void :
     T[P] extends (...args: infer F) => infer R ? (...args: F) => void : 
     T[P];
 }


### PR DESCRIPTION
The compiler barks at `echoer.received().maybeEcho('foo');` when the commented type for `TerminatingObject` is uncommented.

![image](https://user-images.githubusercontent.com/13340/68179140-503cac00-ff54-11e9-955d-be0d6d4cb214.png)
