### PR TITLE
Update test for expected received and didNotReceive behavior

### DIFF
--- a/spec/issues/72.test.ts
+++ b/spec/issues/72.test.ts
@@ -4,59 +4,113 @@ import { Substitute, Arg } from "../../src/index";
 
 interface Calculator {
   add(a: number, b: number): number;
-  subtract(a: number, b: number): number;
-  divide(a: number, b: number): number;
-
-  isEnabled: boolean;
+  mode: boolean;
+  fakeSetting: boolean;
 }
 
-test("check didNotReceive after not mocking and not calling a method", t => {
+test("check didNotReceive and received after not mocking and not calling a method or property", t => {
   const calculator = Substitute.for<Calculator>();
 
   // Do not mock and do not call
+
+  calculator.received(0).add(1, 2);
+  t.throws(() => calculator.received(1).add(1, 2));
   calculator.didNotReceive().add(Arg.any(), Arg.any());
   calculator.didNotReceive().add(1, Arg.any());
   calculator.didNotReceive().add(1, 2);
 
+  calculator.received(0).mode;
+  t.throws(() => calculator.received(1).mode);
+  calculator.didNotReceive().mode;
+
+  calculator.received(0).fakeSetting = true;
+  t.throws(() => calculator.received(1).fakeSetting = true);
+  calculator.didNotReceive().fakeSetting = true;
+
   t.pass();
 });
 
-test("check didNotReceive after not mocking but calling a method", t => {
+test("check didNotReceive and received after not mocking but calling a method or property", t => {
   const calculator = Substitute.for<Calculator>();
 
   // Do not mock, but call
   calculator.add(1, 2);
+  void calculator.mode;
+  calculator.fakeSetting = true;
 
-  calculator.didNotReceive().add(Arg.any(), Arg.any());
-  calculator.didNotReceive().add(1, Arg.any());
-  calculator.didNotReceive().add(1, 2);
+  calculator.received(1).add(1, 2);
+  calculator.received(0).add(2, 2);
+  t.throws(() => calculator.received(1).add(2, 2));
+  t.throws(() => calculator.didNotReceive().add(Arg.any(), Arg.any()));
+  t.throws(() => calculator.didNotReceive().add(1, Arg.any()));
+  t.throws(() => calculator.didNotReceive().add(1, 2));
+
+  calculator.received(1).mode;
+  t.throws(() => calculator.received(0).mode);
+  t.throws(() => calculator.didNotReceive().mode);
+
+  calculator.received(1).fakeSetting = true;
+  t.throws(() => calculator.received(0).fakeSetting = true);
+  t.throws(() => calculator.didNotReceive().fakeSetting = true);
 
   t.pass();
 });
 
-test("check didNotReceive after mocking but not calling a method", t => {
+test("check didNotReceive and received after mocking but not calling a method or property", t => {
   const calculator = Substitute.for<Calculator>();
 
   // Mock but do not call
   calculator.add(1, 2).returns(3);
+  calculator.mode.returns(true);
 
+  calculator.received(0).add(1, 2);
+  t.throws(() => calculator.received(1).add(1, 2));
   calculator.didNotReceive().add(Arg.any(), Arg.any());
   calculator.didNotReceive().add(1, Arg.any());
   calculator.didNotReceive().add(1, 2);
 
+  calculator.received(0).mode;
+  t.throws(() => calculator.received(1).mode);
+  calculator.didNotReceive().mode;
+
   t.pass();
 });
 
-test("check didNotReceive after mocking and calling a method", t => {
+test("check didNotReceive and received after mocking and calling a method or property", t => {
   const calculator = Substitute.for<Calculator>();
 
   // Mock and call
   calculator.add(1, 2).returns(3);
   calculator.add(1, 2);
+  calculator.mode.returns(true);
+  void calculator.mode;
+  calculator.fakeSetting.returns(true);
+  calculator.fakeSetting = true;
 
-  calculator.didNotReceive().add(Arg.any(), Arg.any());
-  calculator.didNotReceive().add(1, Arg.any());
-  calculator.didNotReceive().add(1, 2);
+  calculator.received(1).add(1, 2);
+  t.throws(() => calculator.received(0).add(1, 2));
+  t.throws(() => calculator.received(2).add(1, 2));
+  t.throws(() => calculator.didNotReceive().add(Arg.any(), Arg.any()));
+  t.throws(() => calculator.didNotReceive().add(1, Arg.any()));
+  t.throws(() => calculator.didNotReceive().add(1, 2));
+
+  calculator.received(1).mode;
+  t.throws(() => calculator.received(0).mode);
+  t.throws(() => calculator.didNotReceive().mode);
+
+  calculator.received(1).fakeSetting = true;
+  t.throws(() => calculator.received(0).fakeSetting = true);
+  t.throws(() => calculator.didNotReceive().fakeSetting = true);
+
+  t.pass();
+});
+
+// this test should fail but doesn't
+test("check that received property does both throw and not throw", t => {
+  const calculator = Substitute.for<Calculator>();
+  void calculator.mode;
+  t.throws(() => calculator.received(1).mode);
+  t.notThrows(() => calculator.received(1).mode);
 
   t.pass();
 });


### PR DESCRIPTION
In reference to #72, this updates the test to the expected behavior of the two call count expectation methods. It seems the current master isn't quite working as expected, and `received(0)` isn't a sufficient substitute since it should be possible to ensure a function wasn't called even when it's not called. For example:

```
test("can call received without a call", t => {
  const sub = Substitute.for<Calculator>();
  sub.received(0).add(2, 2);
  t.pass();
});
```

I tried to fix the code by adding a `didNotReceive` property case to `InitialState.get` but couldn't quite get all cases working. The way I got almost all cases working was to "alias" it to `received` with a count 0 and then update the `receivedProxy` to handle not having called the function in the test. I'm happy to put the code in a gist, but I have a hunch that it's not the correct way to accomplish it.

Note that this PR causes the tests to fail.