### PR TITLE
Fix for .returns object inequality

### DIFF
--- a/spec/issues/36.test.ts
+++ b/spec/issues/36.test.ts
@@ -2,19 +2,70 @@ import test from 'ava';
 
 import { Substitute, Arg } from '../../src/index';
 
-interface IData { serverCheck: Date, data: { a: any[] } }
-interface IFetch { getUpdates: (arg: Date | null) => Promise<IData>  }
+class Key {
+    private constructor(private _value: string) { }
+    static create() {
+        return new this('123');
+    }
+    get value(): string {
+        return this._value;
+    }
+}
+class IData {
+    private constructor(private _serverCheck: Date, private _data: number[]) { }
+
+    static create() {
+        return new this(new Date(), [1]);
+    }
+
+    set data(newData: number[]) {
+        this._data = newData;
+    }
+
+    get serverCheck(): Date {
+        return this._serverCheck;
+    }
+
+    get data(): number[] {
+        return this._data;
+    }
+}
+abstract class IFetch {
+    abstract getUpdates(arg: Key): Promise<IData>
+    abstract storeUpdates(arg: IData): Promise<void>
+}
+class Service {
+    constructor(private _database: IFetch) { }
+    public async handle(arg?: Key) {
+        const updateData = await this.getData(arg);
+        updateData.data = [100];
+        await this._database.storeUpdates(updateData);
+    }
+    private getData(arg?: Key) {
+        return this._database.getUpdates(arg);
+    }
+}
 
 test('issue 36 - promises returning object with properties', async t => {
     const emptyFetch = Substitute.for<IFetch>();
-    const now = new Date();
-    emptyFetch.getUpdates(null).returns(Promise.resolve<IData>({
-        serverCheck: now,
-        data: { a: [1] }
-    }));
-    const result = await emptyFetch.getUpdates(null);
+    emptyFetch.getUpdates(Key.create()).returns(Promise.resolve<IData>(IData.create()));
+    const result = await emptyFetch.getUpdates(Key.create());
     t.true(result.serverCheck instanceof Date, 'given date is instanceof Date');
-    t.is(result.serverCheck, now, 'dates are the same');
-    t.true(Array.isArray(result.data.a), 'deep array isArray');
-    t.deepEqual(result.data.a, [1], 'arrays are deep equal');
+    t.deepEqual(result.data, [1], 'arrays are deep equal')
+});
+
+test('using objects or classes as arguments should be able to match mock', async t => {
+    const db = Substitute.for<IFetch>();
+    const data = IData.create();
+    db.getUpdates(Key.create()).returns(Promise.resolve(data));
+    const service = new Service(db);
+
+    await service.handle(Key.create());
+
+    db.received(1).storeUpdates(Arg.is((arg: IData) =>
+        arg.serverCheck instanceof Date &&
+        arg instanceof IData &&
+        arg.data[0] === 100
+    ));
+    t.pass();
 });

--- a/src/Arguments.ts
+++ b/src/Arguments.ts
@@ -13,7 +13,7 @@ export class Argument<T> {
         return this.description;
     }
 
-    inspect() {
+    [Symbol.for('nodejs.util.inspect.custom')]() {
         return this.description;
     }
 }

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -4,6 +4,8 @@ import { HandlerKey } from "./Substitute";
 import { Type } from "./Utilities";
 import { SetPropertyState } from "./states/SetPropertyState";
 
+class SubstituteJS { }
+
 export class Context {
     private _initialState: InitialState;
 
@@ -20,19 +22,21 @@ export class Context {
         this._setState = this._initialState
         this._getState = this._initialState;
 
-        this._proxy = new Proxy(() => { }, {
+        this._proxy = new Proxy(SubstituteJS, {
             apply: (_target, _this, args) => this.apply(_target, _this, args),
             set: (_target, property, value) => (this.set(_target, property, value), true),
-            get: (_target, property) => this.get(_target, property)
+            get: (_target, property) => this.get(_target, property),
+            getOwnPropertyDescriptor: (obj, prop) => prop === 'constructor' ?
+                { value: obj, configurable: true } : Reflect.getOwnPropertyDescriptor(obj, prop)
         });
 
-        this._rootProxy = new Proxy(() => { }, {
+        this._rootProxy = new Proxy(SubstituteJS, {
             apply: (_target, _this, args) => this.initialState.apply(this, args),
             set: (_target, property, value) => (this.initialState.set(this, property, value), true),
             get: (_target, property) => this.initialState.get(this, property)
         });
 
-        this._receivedProxy = new Proxy(() => { }, {
+        this._receivedProxy = new Proxy(SubstituteJS, {
             apply: (_target, _this, args) => this._receivedState === void 0 ? void 0 : this._receivedState.apply(this, args),
             set: (_target, property, value) => (this.set(_target, property, value), true),
             get: (_target, property) => {

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -7,8 +7,8 @@ import util = require('util')
 export type Call = any[] // list of args
 
 export enum Type {
-  method = 'method',
-  property = 'property'
+    method = 'method',
+    property = 'property'
 }
 
 export function stringifyArguments(args: any[]) {
@@ -32,7 +32,7 @@ export function areArgumentArraysEqual(a: any[], b: any[]) {
 
 export function stringifyCalls(calls: Call[]) {
 
-    if(calls.length === 0)
+    if (calls.length === 0)
         return ' (no calls)';
 
     let output = '';
@@ -44,22 +44,43 @@ export function stringifyCalls(calls: Call[]) {
 };
 
 export function areArgumentsEqual(a: any, b: any) {
-    
-    if(a instanceof Argument && b instanceof Argument) {
-        return false;
-    }
 
-    if(a instanceof AllArguments || b instanceof AllArguments)
+    if (a instanceof Argument && b instanceof Argument)
+        return false;
+
+    if (a instanceof AllArguments || b instanceof AllArguments)
         return true;
 
-    if(a instanceof Argument) 
+    if (a instanceof Argument)
         return a.matches(b);
 
-    if(b instanceof Argument)
+    if (b instanceof Argument)
         return b.matches(a);
 
-    return a === b;
+    return deepEqual(a, b);
 };
+
+function deepEqual(a: any, b: any): boolean {
+    if (Array.isArray(a)) {
+        if (!Array.isArray(b) || a.length !== b.length)
+            return false;
+        for (let i = 0; i < a.length; i++) {
+            if (!deepEqual(a[i], b[i]))
+                return false;
+        }
+        return true;
+    }
+    if (typeof a === 'object' && a !== null && b !== null) {
+        if (!(typeof b === 'object')) return false;
+        const keys = Object.keys(a);
+        if (keys.length !== Object.keys(b).length) return false;
+        for (const key in a) {
+            if (!deepEqual(a[key], b[key])) return false;
+        }
+        return true;
+    }
+    return a === b;
+}
 
 export function Get(recorder: InitialState, context: Context, property: PropertyKey) {
     const existingGetState = recorder.getPropertyStates.find(state => state.property === property);

--- a/src/states/InitialState.ts
+++ b/src/states/InitialState.ts
@@ -8,8 +8,8 @@ import { AreProxiesDisabledKey } from "../Substitute";
 export class InitialState implements ContextState {
     private recordedGetPropertyStates: Map<PropertyKey, GetPropertyState>;
     private recordedSetPropertyStates: SetPropertyState[];
-    
-    private _expectedCount: number|undefined|null;
+
+    private _expectedCount: number | undefined | null;
     private _areProxiesDisabled: boolean;
 
     public get expectedCount() {
@@ -47,28 +47,28 @@ export class InitialState implements ContextState {
     }
 
     assertCallCountMatchesExpectations(
-      calls: Call[], // list of arguments
-      callCount: number,
-      type: Type, // method or property
-      property: PropertyKey,
-      args: any[]
+        calls: Call[], // list of arguments
+        callCount: number,
+        type: Type, // method or property
+        property: PropertyKey,
+        args: any[]
     ) {
         const expectedCount = this._expectedCount;
 
         this.clearExpectations();
-        if(this.doesCallCountMatchExpectations(expectedCount, callCount))
+        if (this.doesCallCountMatchExpectations(expectedCount, callCount))
             return;
-    
+
         throw new Error(
-            'Expected ' + (expectedCount === null ? '1 or more' : expectedCount) + 
-            ' call' + (expectedCount === 1 ? '' : 's') + ' to the ' + type + ' ' + property.toString() + 
-            ' with ' + stringifyArguments(args) + ', but received ' + (callCount === 0 ? 'none' : callCount) + 
-            ' of such call' + (callCount === 1 ? '' : 's') + 
+            'Expected ' + (expectedCount === null ? '1 or more' : expectedCount) +
+            ' call' + (expectedCount === 1 ? '' : 's') + ' to the ' + type + ' ' + property.toString() +
+            ' with ' + stringifyArguments(args) + ', but received ' + (callCount === 0 ? 'none' : callCount) +
+            ' of such call' + (callCount === 1 ? '' : 's') +
             '.\nAll calls received to ' + type + ' ' + property.toString() + ':' + stringifyCalls(calls)
         );
     }
 
-    private doesCallCountMatchExpectations(expectedCount: number|undefined|null, actualCount: number) {
+    private doesCallCountMatchExpectations(expectedCount: number | undefined | null, actualCount: number) {
         if (expectedCount === void 0)
             return true;
 
@@ -82,7 +82,7 @@ export class InitialState implements ContextState {
     }
 
     set(context: Context, property: PropertyKey, value: any) {
-        if(property === AreProxiesDisabledKey) {
+        if (property === AreProxiesDisabledKey) {
             this._areProxiesDisabled = value;
             return;
         }
@@ -102,10 +102,13 @@ export class InitialState implements ContextState {
 
     get(context: Context, property: PropertyKey) {
         if (typeof property === 'symbol') {
-            if(property === AreProxiesDisabledKey)
+            if (property === AreProxiesDisabledKey)
                 return this._areProxiesDisabled;
 
             if (property === Symbol.toPrimitive)
+                return () => '{SubstituteJS fake}';
+
+            if (property.toString() === 'Symbol(util.inspect.custom)')
                 return () => '{SubstituteJS fake}';
 
             if (property === Symbol.iterator)
@@ -113,8 +116,6 @@ export class InitialState implements ContextState {
 
             if (property === Symbol.toStringTag)
                 return 'Substitute';
-            if(property.toString() === 'Symbol(util.inspect.custom)')
-                return void 0;
         }
 
         if (property === 'valueOf')


### PR DESCRIPTION
Fixes #36 

This fixes the issue of ticket 36. It didn't have anything to do with promises, but with how the arguments equality for a mock with .return was performed.
So if we mocked a method where one of the arguments was an object or class, unless the object had the same reference, [`areArgumentsEqual` function returned false](https://github.com/ffMathy/FluffySpoon.JavaScript.Testing.Faking/blob/master/src/Utilities.ts#L61).
```typescript
const a = { value: 1 }
const b = a
a === b // true

const c = { value: 1 }
a === c // false
```
When this ocurred, the mocked method / property, instead of returning the expected value, it returned context.proxy, which had all sort of side effects, one of them being that sometimes an error was thrown with the message `Cannot convert object to primitive value`.

---
I made a little change on the proxies, they are based now on a dummy SubstituteJS class. I'm not sure yet if this will help with debugging when something goes wrong, but by doing that, and adding the getOwnPropertyDescriptor handler, instead of getting the arguments not matching error with the generic [[Function]], it will write [[SubstituteJS]]

```js
Error {
    message: `Expected 1 call to the method storeUpdates with arguments.....
    ....All calls received to method storeUpdates:␊
    -> call with arguments [[Function]]`,
  }
// ------
VS
// ------
Error {
    message: `Expected 1 call to the method storeUpdates with arguments....
    .....All calls received to method storeUpdates:␊
    -> call with arguments [[SubstituteJS]]`,
  }
```