### PR TITLE
Implement throws and mimicks behaviour fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,24 @@ console.log(fakeCalculator.divide(10, 5)); //prints 5
 console.log(fakeCalculator.divide(9, 5)); //prints 1338
 ```
 
+## Throwing exceptions
+Exceptions can be thrown on properties or methods. You can add different exceptions for different arguments
+
+```typescript
+import { Substitute, Arg } from '@fluffy-spoon/substitute';
+
+interface Calculator {
+  add(a: number, b: number): number;
+  subtract(a: number, b: number): number;
+  divide(a: number, b: number): number;
+  isEnabled: boolean;
+}
+
+const calculator = Substitute.for<Calculator>();
+calculator.divide(Arg.any(), 0).throws(new Error('Cannot divide by 0'));
+calculator.divide(1, 0); // throws the exception Error: Cannot divide by 0
+```
+
 # Benefits over other mocking libraries
 - Easier-to-understand fluent syntax.
 - No need to cast to `any` in certain places (for instance, when overriding read-only properties) due to the `myProperty.returns(...)` syntax.

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,9 +174,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
+      "version": "13.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
+      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/spec/throws.spec.ts
+++ b/spec/throws.spec.ts
@@ -1,0 +1,42 @@
+import test from 'ava'
+
+import { Substitute, Arg } from '../src/index'
+
+interface Calculator {
+  add(a: number, b: number): number
+  divide(a: number, b: number): number
+  mode: boolean
+  fakeSetting: boolean
+}
+
+test('throws on a method with arguments', t => {
+  const calculator = Substitute.for<Calculator>()
+  calculator.divide(Arg.any(), 0).throws(new Error('Cannot divide by 0'))
+
+  t.throws(() => calculator.divide(1, 0), { instanceOf: Error, message: 'Cannot divide by 0' })
+})
+
+test('throws on a property being called', t => {
+  const calculator = Substitute.for<Calculator>()
+  calculator.mode.throws(new Error('Property not set'))
+
+  t.throws(() => calculator.mode, { instanceOf: Error, message: 'Property not set' })
+})
+
+test('does not throw on methods that do not match arguments', t => {
+  const calculator = Substitute.for<Calculator>()
+  calculator.divide(Arg.any(), 0).throws(new Error('Cannot divide by 0'))
+  calculator.divide(4, 2).returns(2)
+
+  t.is(2, calculator.divide(4, 2))
+  t.throws(() => calculator.divide(1, 0), { instanceOf: Error, message: 'Cannot divide by 0' })
+})
+
+test('can set multiple throws for same method with different arguments', t => {
+  const calculator = Substitute.for<Calculator>()
+  calculator.divide(Arg.any(), 0).throws(new Error('Cannot divide by 0'))
+  calculator.divide(Arg.any(), Arg.is(number => !Number.isInteger(number))).throws(new Error('Only integers supported'))
+
+  t.throws(() => calculator.divide(1, 1.135), { instanceOf: Error, message: 'Only integers supported' })
+  t.throws(() => calculator.divide(1, 0), { instanceOf: Error, message: 'Cannot divide by 0' })
+})

--- a/src/Transformations.ts
+++ b/src/Transformations.ts
@@ -1,16 +1,17 @@
 import { AllArguments } from "./Arguments";
 
-export type NoArgumentFunctionSubstitute<TReturnType> = 
+export type NoArgumentFunctionSubstitute<TReturnType> =
     (() => (TReturnType & NoArgumentMockObjectMixin<TReturnType>))
 
-export type FunctionSubstitute<TArguments extends any[], TReturnType> = 
-    ((...args: TArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>)) & 
+export type FunctionSubstitute<TArguments extends any[], TReturnType> =
+    ((...args: TArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>)) &
     ((allArguments: AllArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>))
 
 export type PropertySubstitute<TReturnType> = (TReturnType & Partial<NoArgumentMockObjectMixin<TReturnType>>);
 
 type BaseMockObjectMixin<TReturnType> = {
     returns: (...args: TReturnType[]) => void;
+    throws: (exception: any) => void;
 }
 
 type NoArgumentMockObjectMixin<TReturnType> = BaseMockObjectMixin<TReturnType> & {
@@ -30,7 +31,7 @@ export type ObjectSubstitute<T extends Object, K extends Object = T> = ObjectSub
 type TerminatingObject<T> = {
     [P in keyof T]:
     T[P] extends () => infer R ? () => void :
-    T[P] extends (...args: infer F) => infer R ? (...args: F) => void : 
+    T[P] extends (...args: infer F) => infer R ? (...args: F) => void :
     T[P];
 }
 
@@ -43,6 +44,6 @@ type ObjectSubstituteTransformation<T extends Object> = {
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export type OmitProxyMethods<T extends any> = Omit<T, 'mimick'|'received'|'didNotReceive'>;
+export type OmitProxyMethods<T extends any> = Omit<T, 'mimick' | 'received' | 'didNotReceive'>;
 
 export type DisabledSubstituteObject<T> = T extends ObjectSubstitute<OmitProxyMethods<infer K>, infer K> ? K : never;

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -11,6 +11,9 @@ export enum Type {
     property = 'property'
 }
 
+export const Nothing = Symbol();
+export type Nothing = typeof Nothing
+
 export function stringifyArguments(args: any[]) {
     args = args.map(x => util.inspect(x));
     return args && args.length > 0 ? 'arguments [' + args.join(', ') + ']' : 'no arguments';
@@ -62,16 +65,15 @@ export function areArgumentsEqual(a: any, b: any) {
 
 function deepEqual(a: any, b: any): boolean {
     if (Array.isArray(a)) {
-        if (!Array.isArray(b) || a.length !== b.length)
-            return false;
+        if (!Array.isArray(b) || a.length !== b.length) return false;
         for (let i = 0; i < a.length; i++) {
-            if (!deepEqual(a[i], b[i]))
-                return false;
+            if (!deepEqual(a[i], b[i])) return false;
         }
         return true;
     }
     if (typeof a === 'object' && a !== null && b !== null) {
         if (!(typeof b === 'object')) return false;
+        if (a.constructor !== b.constructor) return false;
         const keys = Object.keys(a);
         if (keys.length !== Object.keys(b).length) return false;
         for (const key in a) {

--- a/src/states/SetPropertyState.ts
+++ b/src/states/SetPropertyState.ts
@@ -2,8 +2,6 @@ import { ContextState, PropertyKey } from "./ContextState";
 import { Context } from "src/Context";
 import { areArgumentsEqual, Type } from "../Utilities";
 
-const Nothing = Symbol();
-
 export class SetPropertyState implements ContextState {
     private _callCount: number;
     private _arguments: any[];


### PR DESCRIPTION
Closes #67
- Implements `.throws`method
- Fixes `.mimicks` ignoring arguments - the mimicks function was always being executed, the arguments that should have been matched were ignored

It makes me a bit uncomfortable to give`.throws` an argument of type any, but according to the js spec, anything can be thrown.
~~*Documentation for `.throws` needs to be added*~~

---

I would like to refactor (not in this pr) a bit the code, mostly name changes, grouping stuff and cleaner tests. To start to work on that, I really think it would be great to add lint rules, to have all the code of this repository with the same format. Do you have any lint preferences?