### PR TITLE
Fix received optional parameter issue and better debuggability

### DIFF
--- a/spec/issues/51.test.ts
+++ b/spec/issues/51.test.ts
@@ -15,6 +15,6 @@ test('issue 51 - All functions shares the same state', async t => {
     try {
         calculator.received().divide(1, 2);
     } catch (e) {
-        t.regex(e.toString(), /Error: there is no mock for property: divide/);
+        t.regex(e.toString(), /SubstituteException: There is no mock for property: divide/);
     }
 });

--- a/spec/issues/59.test.ts
+++ b/spec/issues/59.test.ts
@@ -13,6 +13,6 @@ test('issue 59 - Mock function with optional parameters', (t) => {
   echoer.maybeEcho().returns('baz')
 
   t.is(echoer.maybeEcho('foo'), 'bar')
-  // echoer.received().maybeEcho('foo');
+  echoer.received().maybeEcho('foo');
   t.is(echoer.maybeEcho(), 'baz')
 })

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -53,7 +53,6 @@ export class Context {
             case 'constructor':
             case 'valueOf':
             case '$$typeof':
-            case '$$typeof':
             case 'length':
             case 'toString':
             case 'inspect':

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -4,7 +4,7 @@ import { InitialState } from "./states/InitialState";
 import { HandlerKey } from "./Substitute";
 import { Type } from "./Utilities";
 import { SetPropertyState } from "./states/SetPropertyState";
-import { SubstituteBase as SubstituteJS, SubstituteException } from './SubstituteBase'
+import { SubstituteJS as SubstituteBase, SubstituteException } from './SubstituteBase'
 
 export class Context {
     private _initialState: InitialState;
@@ -22,19 +22,19 @@ export class Context {
         this._setState = this._initialState;
         this._getState = this._initialState;
 
-        this._proxy = new Proxy(SubstituteJS, {
+        this._proxy = new Proxy(SubstituteBase, {
             apply: (_target, _this, args) => this.apply(_target, _this, args),
             set: (_target, property, value) => (this.set(_target, property, value), true),
             get: (_target, property) => this._filterAndReturnProperty(_target, property, this.get)
         });
 
-        this._rootProxy = new Proxy(SubstituteJS, {
+        this._rootProxy = new Proxy(SubstituteBase, {
             apply: (_target, _this, args) => this.initialState.apply(this, args),
             set: (_target, property, value) => (this.initialState.set(this, property, value), true),
             get: (_target, property) => this._filterAndReturnProperty(_target, property, this.rootGet)
         });
 
-        this._receivedProxy = new Proxy(SubstituteJS, {
+        this._receivedProxy = new Proxy(SubstituteBase, {
             apply: (_target, _this, args) => this._receivedState === void 0 ? void 0 : this._receivedState.apply(this, args),
             set: (_target, property, value) => (this.set(_target, property, value), true),
             get: (_target, property) => {
@@ -48,7 +48,7 @@ export class Context {
         });
     }
 
-    private _filterAndReturnProperty(target: typeof SubstituteJS, property: PropertyKey, defaultGet: Context['get']) {
+    private _filterAndReturnProperty(target: typeof SubstituteBase, property: PropertyKey, defaultGet: Context['get']) {
         switch (property) {
             case 'constructor':
             case 'valueOf':

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -1,10 +1,10 @@
+import { inspect } from 'util'
 import { ContextState } from "./states/ContextState";
 import { InitialState } from "./states/InitialState";
 import { HandlerKey } from "./Substitute";
 import { Type } from "./Utilities";
 import { SetPropertyState } from "./states/SetPropertyState";
-
-class SubstituteJS { }
+import { SubstituteBase as SubstituteJS, SubstituteException } from './SubstituteBase'
 
 export class Context {
     private _initialState: InitialState;
@@ -19,21 +19,19 @@ export class Context {
 
     constructor() {
         this._initialState = new InitialState();
-        this._setState = this._initialState
+        this._setState = this._initialState;
         this._getState = this._initialState;
 
         this._proxy = new Proxy(SubstituteJS, {
             apply: (_target, _this, args) => this.apply(_target, _this, args),
             set: (_target, property, value) => (this.set(_target, property, value), true),
-            get: (_target, property) => this.get(_target, property),
-            getOwnPropertyDescriptor: (obj, prop) => prop === 'constructor' ?
-                { value: obj, configurable: true } : Reflect.getOwnPropertyDescriptor(obj, prop)
+            get: (_target, property) => this._filterAndReturnProperty(_target, property, this.get)
         });
 
         this._rootProxy = new Proxy(SubstituteJS, {
             apply: (_target, _this, args) => this.initialState.apply(this, args),
             set: (_target, property, value) => (this.initialState.set(this, property, value), true),
-            get: (_target, property) => this.initialState.get(this, property)
+            get: (_target, property) => this._filterAndReturnProperty(_target, property, this.rootGet)
         });
 
         this._receivedProxy = new Proxy(SubstituteJS, {
@@ -50,12 +48,41 @@ export class Context {
         });
     }
 
+    private _filterAndReturnProperty(target: typeof SubstituteJS, property: PropertyKey, defaultGet: Context['get']) {
+        switch (property) {
+            case 'constructor':
+            case 'valueOf':
+            case '$$typeof':
+            case '$$typeof':
+            case 'length':
+            case 'toString':
+            case 'inspect':
+            case 'lastRegisteredSubstituteJSMethodOrProperty':
+                return target.prototype[property];
+            case Symbol.toPrimitive:
+                return target.prototype[Symbol.toPrimitive];
+            case inspect.custom:
+                return target.prototype[inspect.custom];
+            case Symbol.iterator:
+                return target.prototype[Symbol.iterator];
+            case Symbol.toStringTag:
+                return target.prototype[Symbol.toStringTag];
+            default:
+                target.prototype.lastRegisteredSubstituteJSMethodOrProperty = property.toString()
+                return defaultGet.bind(this)(target, property);
+        }
+    }
+
     private handleNotFoundState(property: PropertyKey) {
         if (this.initialState.hasExpectations && this.initialState.expectedCount !== null) {
             this.initialState.assertCallCountMatchesExpectations([], 0, Type.property, property, []);
             return this.receivedProxy;
         }
-        throw new Error(`there is no mock for property: ${String(property)}`);
+        throw SubstituteException.forPropertyNotMocked(property);
+    }
+
+    rootGet(_target: any, property: PropertyKey) {
+        return this.initialState.get(this, property);
     }
 
     apply(_target: any, _this: any, args: any[]) {

--- a/src/SubstituteBase.ts
+++ b/src/SubstituteBase.ts
@@ -1,7 +1,7 @@
 import { inspect } from 'util';
 import { Type, stringifyArguments, stringifyCalls, Call } from './Utilities';
 
-export class SubstituteBase {
+export class SubstituteJS {
   private _lastRegisteredSubstituteJSMethodOrProperty: string
   set lastRegisteredSubstituteJSMethodOrProperty(value: string) {
     this._lastRegisteredSubstituteJSMethodOrProperty = value;

--- a/src/SubstituteBase.ts
+++ b/src/SubstituteBase.ts
@@ -1,0 +1,73 @@
+import { inspect } from 'util';
+import { Type, stringifyArguments, stringifyCalls, Call } from './Utilities';
+
+export class SubstituteBase {
+  private _lastRegisteredSubstituteJSMethodOrProperty: string
+  set lastRegisteredSubstituteJSMethodOrProperty(value: string) {
+    this._lastRegisteredSubstituteJSMethodOrProperty = value;
+  }
+  get lastRegisteredSubstituteJSMethodOrProperty() {
+    return typeof this._lastRegisteredSubstituteJSMethodOrProperty === 'undefined' ? 'root' : this._lastRegisteredSubstituteJSMethodOrProperty;
+  }
+  [Symbol.toPrimitive]() {
+    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+  }
+  [Symbol.toStringTag]() {
+    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+  }
+  [Symbol.iterator]() {
+    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+  }
+  [inspect.custom]() {
+    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+  }
+  valueOf() {
+    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+  }
+  $$typeof() {
+    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+  }
+  toString() {
+    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+  }
+  inspect() {
+    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+  }
+  length = `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+}
+
+enum SubstituteExceptionTypes {
+  CallCountMissMatch = 'CallCountMissMatch',
+  PropertyNotMocked = 'PropertyNotMocked'
+}
+
+export class SubstituteException extends Error {
+  type: SubstituteExceptionTypes
+  private constructor(msg: string, exceptionType?: SubstituteExceptionTypes) {
+    super(msg);
+    Error.captureStackTrace(this, SubstituteException);
+    this.name = new.target.name;
+    this.type = exceptionType
+  }
+
+  static forCallCountMissMatch(
+    callCount: { expected: number | null, received: number },
+    property: { type: Type, value: PropertyKey },
+    calls: { expectedArguments: any[], received: Call[] }
+  ) {
+    const message = 'Expected ' + (callCount.expected === null ? '1 or more' : callCount.expected) +
+      ' call' + (callCount.expected === 1 ? '' : 's') + ' to the ' + property.type + ' ' + property.value.toString() +
+      ' with ' + stringifyArguments(calls.expectedArguments) + ', but received ' + (callCount.received === 0 ? 'none' : callCount.received) +
+      ' of such call' + (callCount.received === 1 ? '' : 's') +
+      '.\nAll calls received to ' + property.type + ' ' + property.value.toString() + ':' + stringifyCalls(calls.received);
+    return new this(message, SubstituteExceptionTypes.CallCountMissMatch);
+  }
+
+  static forPropertyNotMocked(property: PropertyKey) {
+    return new this(`There is no mock for property: ${String(property)}`, SubstituteExceptionTypes.PropertyNotMocked)
+  }
+
+  static generic(message: string) {
+    return new this(message)
+  }
+}

--- a/src/Transformations.ts
+++ b/src/Transformations.ts
@@ -30,8 +30,8 @@ export type ObjectSubstitute<T extends Object, K extends Object = T> = ObjectSub
 
 type TerminatingObject<T> = {
     [P in keyof T]:
-    T[P] extends () => infer R ? () => void :
-    T[P] extends (...args: infer F) => infer R ? (...args: F) => void :
+    T[P] extends (...args: infer F) => any ? (...args: F) => void :
+    T[P] extends () => any ? () => void :
     T[P];
 }
 

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -1,14 +1,22 @@
 import { Argument, AllArguments } from "./Arguments";
-import { GetPropertyState } from './states/GetPropertyState'
-import { InitialState } from './states/InitialState'
-import { Context } from './Context'
-import util = require('util')
+import { GetPropertyState } from './states/GetPropertyState';
+import { InitialState } from './states/InitialState';
+import { Context } from './Context';
+import * as util from 'util';
 
 export type Call = any[] // list of args
 
 export enum Type {
     method = 'method',
     property = 'property'
+}
+
+export enum SubstituteMethods {
+    received = 'received',
+    didNotReceive = 'didNotReceive',
+    mimicks = 'mimicks',
+    throws = 'throws',
+    returns = 'returns'
 }
 
 export const Nothing = Symbol();

--- a/src/states/FunctionState.ts
+++ b/src/states/FunctionState.ts
@@ -1,7 +1,8 @@
 import { ContextState, PropertyKey } from "./ContextState";
 import { Context } from "src/Context";
-import { areArgumentArraysEqual, Call, Type } from "../Utilities";
+import { SubstituteMethods, areArgumentArraysEqual, Call, Type } from "../Utilities";
 import { GetPropertyState } from "./GetPropertyState";
+import { SubstituteException } from "../SubstituteBase";
 
 interface ReturnMock {
     args: Call
@@ -100,10 +101,10 @@ export class FunctionState implements ContextState {
         if (property === 'then')
             return void 0;
 
-        if (property === 'mimicks') {
+        if (property === SubstituteMethods.mimicks) {
             return (input: Function) => {
                 if (!this._lastArgs) {
-                    throw new Error('Eh, there\'s a bug, no args recorded for this mimicks :/')
+                    throw SubstituteException.generic('Eh, there\'s a bug, no args recorded for this mimicks :/')
                 }
                 this.mimicks.push({
                     args: this._lastArgs,
@@ -115,10 +116,10 @@ export class FunctionState implements ContextState {
             }
         }
 
-        if (property === 'throws') {
+        if (property === SubstituteMethods.throws) {
             return (input: Error | Function) => {
                 if (!this._lastArgs) {
-                    throw new Error('Eh, there\'s a bug, no args recorded for this throw :/')
+                    throw SubstituteException.generic('Eh, there\'s a bug, no args recorded for this throw :/')
                 }
                 this.throws.push({
                     args: this._lastArgs,
@@ -129,10 +130,10 @@ export class FunctionState implements ContextState {
             }
         }
 
-        if (property === 'returns') {
+        if (property === SubstituteMethods.returns) {
             return (...returns: any[]) => {
                 if (!this._lastArgs) {
-                    throw new Error('Eh, there\'s a bug, no args recorded for this return :/')
+                    throw SubstituteException.generic('Eh, there\'s a bug, no args recorded for this return :/')
                 }
                 this.returns.push({
                     returnValues: returns,

--- a/src/states/SetPropertyState.ts
+++ b/src/states/SetPropertyState.ts
@@ -1,6 +1,7 @@
 import { ContextState, PropertyKey } from "./ContextState";
 import { Context } from "src/Context";
 import { areArgumentsEqual, Type } from "../Utilities";
+import { SubstituteException } from "../SubstituteBase";
 
 export class SetPropertyState implements ContextState {
     private _callCount: number;
@@ -25,13 +26,13 @@ export class SetPropertyState implements ContextState {
     }
 
     apply(context: Context): undefined {
-        throw new Error('Calling apply of setPropertyState is not normal behaviour, something gone wrong')
+        throw SubstituteException.generic('Calling apply of setPropertyState is not normal behaviour, something gone wrong')
     }
 
     set(context: Context, property: PropertyKey, value: any) {
         let callCount = this._callCount;
         const hasExpectations = context.initialState.hasExpectations;
-        if(hasExpectations) {
+        if (hasExpectations) {
             callCount = context.initialState
                 .setPropertyStates
                 .filter(x => areArgumentsEqual(x.arguments[0], value))
@@ -46,12 +47,12 @@ export class SetPropertyState implements ContextState {
             this.property,
             this.arguments);
 
-        if(!hasExpectations) {
+        if (!hasExpectations) {
             this._callCount++;
         }
     }
 
     get(context: Context, property: PropertyKey): undefined {
-        throw new Error('Calling get of setPropertyState is not normal behaviour, something gone wrong')
+        throw SubstituteException.generic('Calling get of setPropertyState is not normal behaviour, something gone wrong')
     }
 }


### PR DESCRIPTION
Closes #59 
The issue with the received optional parameter fixed itself with just swapping the order of the override types for TerminatingObject.

---
This pr replaces some of the hardcoded values around the library with typed ones. It also enhances a lot the logging output of the Substitute proxies, so hopefully no more `TypeError: Cannot convert object to primitive value`. 
Some releases back, when doing a console.log of a non mocked property you would get the TypeError described before. Now it's something like `[Function: SubstituteJS] -> add`, where `add` is the last accessed property / method of the proxy before the logging.