### PR TITLE
Add resolves() and rejects() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ interface Calculator {
   add(a: number, b: number): number;
   subtract(a: number, b: number): number;
   divide(a: number, b: number): number;
+  async heavyOperation(): Promise<number>;
 
   isEnabled: boolean;
 }
@@ -51,6 +52,15 @@ console.log(calculator.add(1, 2)); //prints 3
 console.log(calculator.add(1, 2)); //prints 7
 console.log(calculator.add(1, 2)); //prints 9
 console.log(calculator.add(1, 2)); //prints undefined
+```
+
+## Working with promises
+When working with promises you can also use the method `resolves()` to return a promise.
+
+```typescript
+calculator.heavyOperation(1, 2).resolves(4); 
+//same as calculator.heavyOperation(1, 2).returns(Promise.resolve(4));
+console.log(await calculator.heavyOperation(1, 2)); //prints 4
 ```
 
 ## Verifying calls

--- a/README.md
+++ b/README.md
@@ -55,12 +55,18 @@ console.log(calculator.add(1, 2)); //prints undefined
 ```
 
 ## Working with promises
-When working with promises you can also use the method `resolves()` to return a promise.
+When working with promises you can also use `resolves()` and `rejects()` to return a promise.
 
 ```typescript
 calculator.heavyOperation(1, 2).resolves(4); 
 //same as calculator.heavyOperation(1, 2).returns(Promise.resolve(4));
 console.log(await calculator.heavyOperation(1, 2)); //prints 4
+```
+
+```typescript
+calculator.heavyOperation(1, 2).rejects(new Error());
+//same as calculator.heavyOperation(1, 2).returns(Promise.reject(new Error()));
+console.log(await calculator.heavyOperation(1, 2)); //throws Error
 ```
 
 ## Verifying calls

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -174,6 +174,22 @@ test('returning resolved promises works', async t => {
 	t.is(1338, await substitute.returnPromise());
 });
 
+test('resolving other fake works', async t => {
+	initialize();
+
+	const otherSubstitute = Substitute.for<Dummy>();
+	substitute.returnPromise().resolves(otherSubstitute);
+	t.is(otherSubstitute, await substitute.returnPromise());
+});
+
+test('resolving promises works', async t => {
+	initialize();
+
+	substitute.returnPromise().resolves(1338);
+
+	t.is(1338, await substitute.returnPromise());
+});
+
 test('class void returns', t => {
 	initialize();
 

--- a/spec/throws.spec.ts
+++ b/spec/throws.spec.ts
@@ -5,6 +5,7 @@ import { Substitute, Arg } from '../src/index'
 interface Calculator {
   add(a: number, b: number): number
   divide(a: number, b: number): number
+  heavyOperation(): Promise<number>
   mode: boolean
   fakeSetting: boolean
 }
@@ -14,6 +15,13 @@ test('throws on a method with arguments', t => {
   calculator.divide(Arg.any(), 0).throws(new Error('Cannot divide by 0'))
 
   t.throws(() => calculator.divide(1, 0), { instanceOf: Error, message: 'Cannot divide by 0' })
+})
+
+test('rejects on a method', async t => {
+  const calculator = Substitute.for<Calculator>()
+  calculator.heavyOperation().rejects(new Error('Error'))
+
+  await t.throwsAsync(calculator.heavyOperation, { instanceOf: Error, message: 'Error' })
 })
 
 test('throws on a property being called', t => {

--- a/src/Transformations.ts
+++ b/src/Transformations.ts
@@ -33,10 +33,12 @@ type MockObjectMixin<TArguments extends any[], TReturnType> = BaseMockObjectMixi
 
 type NoArgumentMockObjectPromise<TReturnType> = NoArgumentMockObjectMixin<TReturnType> & {
     resolves: (...args: Unpacked<TReturnType>[]) => void;
+    rejects: (exception: any) => void;
 }
 
 type MockObjectPromise<TArguments extends any[], TReturnType> = MockObjectMixin<TArguments, TReturnType> & {
     resolves: (...args: Unpacked<TReturnType>[]) => void;
+    rejects: (exception: any) => void;
 }
 
 export type ObjectSubstitute<T extends Object, K extends Object = T> = ObjectSubstituteTransformation<T> & {

--- a/src/Transformations.ts
+++ b/src/Transformations.ts
@@ -1,13 +1,22 @@
 import { AllArguments } from "./Arguments";
 
 export type NoArgumentFunctionSubstitute<TReturnType> =
-    (() => (TReturnType & NoArgumentMockObjectMixin<TReturnType>))
+    TReturnType extends Promise<infer U> ?
+        (() => (TReturnType & NoArgumentMockObjectPromise<TReturnType>)) :
+        (() => (TReturnType & NoArgumentMockObjectMixin<TReturnType>))
 
 export type FunctionSubstitute<TArguments extends any[], TReturnType> =
-    ((...args: TArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>)) &
-    ((allArguments: AllArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>))
+    TReturnType extends Promise<infer U> ?
+        ((...args: TArguments) => (TReturnType & MockObjectPromise<TArguments, TReturnType>)) &
+        ((allArguments: AllArguments) => (TReturnType & MockObjectPromise<TArguments, TReturnType>)) :
+        ((...args: TArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>)) &
+        ((allArguments: AllArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>))
 
 export type PropertySubstitute<TReturnType> = (TReturnType & Partial<NoArgumentMockObjectMixin<TReturnType>>);
+
+type Unpacked<T> =
+    T extends Promise<infer U> ? U :
+    T;
 
 type BaseMockObjectMixin<TReturnType> = {
     returns: (...args: TReturnType[]) => void;
@@ -20,6 +29,14 @@ type NoArgumentMockObjectMixin<TReturnType> = BaseMockObjectMixin<TReturnType> &
 
 type MockObjectMixin<TArguments extends any[], TReturnType> = BaseMockObjectMixin<TReturnType> & {
     mimicks: (func: (...args: TArguments) => TReturnType) => void;
+}
+
+type NoArgumentMockObjectPromise<TReturnType> = NoArgumentMockObjectMixin<TReturnType> & {
+    resolves: (...args: Unpacked<TReturnType>[]) => void;
+}
+
+type MockObjectPromise<TArguments extends any[], TReturnType> = MockObjectMixin<TArguments, TReturnType> & {
+    resolves: (...args: Unpacked<TReturnType>[]) => void;
 }
 
 export type ObjectSubstitute<T extends Object, K extends Object = T> = ObjectSubstituteTransformation<T> & {

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -16,7 +16,8 @@ export enum SubstituteMethods {
     didNotReceive = 'didNotReceive',
     mimicks = 'mimicks',
     throws = 'throws',
-    returns = 'returns'
+    returns = 'returns',
+    resolves = 'resolves'
 }
 
 export const Nothing = Symbol();

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -17,7 +17,8 @@ export enum SubstituteMethods {
     mimicks = 'mimicks',
     throws = 'throws',
     returns = 'returns',
-    resolves = 'resolves'
+    resolves = 'resolves',
+    rejects = 'rejects'
 }
 
 export const Nothing = Symbol();

--- a/src/states/FunctionState.ts
+++ b/src/states/FunctionState.ts
@@ -156,6 +156,23 @@ export class FunctionState implements ContextState {
             };
         }
 
+        if (property === SubstituteMethods.resolves) {
+            return (...returns: any[]) => {
+                if (!this._lastArgs) {
+                    throw SubstituteException.generic('Eh, there\'s a bug, no args recorded for this return :/')
+                }
+                returns = returns.map(value => Promise.resolve(value))
+                this.returns.push({
+                    returnValues: returns,
+                    returnIndex: 0,
+                    args: this._lastArgs
+                })
+                this._calls.pop()
+
+                context.state = context.initialState;
+            };
+        }
+
         return context.proxy;
     }
 }


### PR DESCRIPTION
Usually in other test libraries we have available the method `resolves(value)` to be alias to `returns(Promise.resolve(value))`  

```js
substitute.returnPromise().returns(Promise.resolve(1338));
```
becomes:
```js
substitute.returnPromise().resolves(1338);
```

References:
- https://sinonjs.org/releases/v9.0.1/stubs/
- https://jestjs.io/docs/en/asynchronous#resolves--rejects