### PR TITLE
Refactor promise type logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1521,6 +1521,12 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1801,14 +1807,6 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "read-pkg": {

--- a/src/Transformations.ts
+++ b/src/Transformations.ts
@@ -1,26 +1,21 @@
 import { AllArguments } from "./Arguments";
 
-export type NoArgumentFunctionSubstitute<TReturnType> =
-    TReturnType extends Promise<infer U> ?
-        (() => (TReturnType & NoArgumentMockObjectPromise<TReturnType>)) :
-        (() => (TReturnType & NoArgumentMockObjectMixin<TReturnType>))
+export type NoArgumentFunctionSubstitute<TReturnType> = (() => (TReturnType & NoArgumentMockObjectMixin<TReturnType>))
 
 export type FunctionSubstitute<TArguments extends any[], TReturnType> =
-    TReturnType extends Promise<infer U> ?
-        ((...args: TArguments) => (TReturnType & MockObjectPromise<TArguments, TReturnType>)) &
-        ((allArguments: AllArguments) => (TReturnType & MockObjectPromise<TArguments, TReturnType>)) :
-        ((...args: TArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>)) &
-        ((allArguments: AllArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>))
+    ((...args: TArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>)) &
+    ((allArguments: AllArguments) => (TReturnType & MockObjectMixin<TArguments, TReturnType>))
 
 export type PropertySubstitute<TReturnType> = (TReturnType & Partial<NoArgumentMockObjectMixin<TReturnType>>);
 
-type Unpacked<T> =
-    T extends Promise<infer U> ? U :
-    T;
+type MockObjectPromise<TReturnType> = TReturnType extends Promise<infer U> ? {
+    resolves: (...args: U[]) => void;
+    rejects: (exception: any) => void;
+} : {}
 
-type BaseMockObjectMixin<TReturnType> = {
+type BaseMockObjectMixin<TReturnType> = MockObjectPromise<TReturnType> & {
     returns: (...args: TReturnType[]) => void;
-    throws: (exception: any) => void;
+    throws: (exception: any) => never;
 }
 
 type NoArgumentMockObjectMixin<TReturnType> = BaseMockObjectMixin<TReturnType> & {
@@ -29,16 +24,6 @@ type NoArgumentMockObjectMixin<TReturnType> = BaseMockObjectMixin<TReturnType> &
 
 type MockObjectMixin<TArguments extends any[], TReturnType> = BaseMockObjectMixin<TReturnType> & {
     mimicks: (func: (...args: TArguments) => TReturnType) => void;
-}
-
-type NoArgumentMockObjectPromise<TReturnType> = NoArgumentMockObjectMixin<TReturnType> & {
-    resolves: (...args: Unpacked<TReturnType>[]) => void;
-    rejects: (exception: any) => void;
-}
-
-type MockObjectPromise<TArguments extends any[], TReturnType> = MockObjectMixin<TArguments, TReturnType> & {
-    resolves: (...args: Unpacked<TReturnType>[]) => void;
-    rejects: (exception: any) => void;
 }
 
 export type ObjectSubstitute<T extends Object, K extends Object = T> = ObjectSubstituteTransformation<T> & {


### PR DESCRIPTION
This fixes #86 

Either Typescript type inheritance is doing something weird, or we are missing something, but refactoring the promise type to extend `BaseMockObjectMixin` seems to get it right!

The MockObjectPromise type is only applied when the return type of a method or property is a promise.

As I said in the comment on the issue, we need to add tests for as many types as possible, so we can avoid weird issues like with the boolean