### PR TITLE
Fix infinite recursion on circular objects

### DIFF
--- a/spec/issues/90.test.ts
+++ b/spec/issues/90.test.ts
@@ -1,0 +1,37 @@
+import test from 'ava';
+
+import { Substitute } from '../../src/index';
+
+test('can handle circular referenced objects', t => {
+  interface Service {
+    foo(a: any): string;
+  }
+
+  const s = Substitute.for<Service>();
+
+  const parent = {} as any;
+  parent.child = parent;
+
+  const root = {} as any;
+  root.path = { to: { nested: root } };
+
+  s.foo(parent).returns('even-circular');
+  s.foo(root).returns('even-nested-circular');
+
+  t.is(s.foo(parent), 'even-circular');
+  t.is(s.foo(root), 'even-nested-circular');
+});
+
+test('can handle non circular referenced objects', t => {
+  interface Service {
+    foo(a: any): string;
+  }
+
+  const s = Substitute.for<Service>();
+
+  const parent = {} as any;
+  parent.child = { family: true };
+
+  s.foo(parent).returns('even-non-circular');
+  t.is(s.foo(parent), 'even-non-circular');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,16 @@
 {
     "compileOnSave": true,
     "compilerOptions": {
+        "module": "commonjs",
+        "moduleResolution": "node",
         "baseUrl": ".",
-		"declaration": true,
+        "declaration": true,
         "sourceMap": true,
         "inlineSources": true,
         "downlevelIteration": true,
         "outDir": "./dist",
         "strict": true,
         "strictNullChecks": false,
-        "target": "es5",
-        "lib": [
-            "es2015"
-        ]
+        "target": "ES2016"
     }
 }


### PR DESCRIPTION
Fixes #90 
The fix consists in adding an array that stores references of objects seen in the recursion chain. By getting a mutation free array on every iteration, we can ensure that each branch of the recursion chain has only references to previous objects. https://github.com/ffMathy/FluffySpoon.JavaScript.Testing.Faking/blob/a5504549129819044a39f9287a8bd9336e7503a0/src/Utilities.ts#L80

I refactored a bit the deepEqual function. As arrays are objects, we had two loops doing the same thing.
I had to bump the target of typescript. We were using quite an old one, it didn't support `Array.prototype.includes`. From what I can see on the Github Action, we aim to support node 8. ES2016 is 100% compatible with node 8 (https://node.green/#ES2016).
It may not be relevant but official maintenance for node 8 finished on January this year!