### PR TITLE
Add support for up to five function overloads

### DIFF
--- a/src/Transformations.ts
+++ b/src/Transformations.ts
@@ -1,6 +1,6 @@
 import { AllArguments } from "./Arguments";
 
-type FunctionSubstituteWithOverrides<TFunc, Terminating = false> =
+type FunctionSubstituteWithOverloads<TFunc, Terminating = false> =
     TFunc extends {
         (...args: infer A1): infer R1;
         (...args: infer A2): infer R2;
@@ -76,7 +76,7 @@ type TerminatingObject<T> = {
     [P in keyof T]:
     T[P] extends (...args: infer F) => any ?
     F extends [] ? () => void :
-    FunctionSubstituteWithOverrides<T[P], true> :
+    FunctionSubstituteWithOverloads<T[P], true> :
     T[P];
 }
 
@@ -84,7 +84,7 @@ type ObjectSubstituteTransformation<T extends Object> = {
     [P in keyof T]:
     T[P] extends (...args: infer F) => infer R ?
     F extends [] ? NoArgumentFunctionSubstitute<R> :
-    FunctionSubstituteWithOverrides<T[P]> :
+    FunctionSubstituteWithOverloads<T[P]> :
     PropertySubstitute<T[P]>;
 }
 


### PR DESCRIPTION
Closes #93 

Due to some typescript limitations, it's not possible to to get all the parameters and return types of functions with overloads. That's why when inferring the parameters or return type of a method, we would only get the last defined overload of such method. 
One of the main problems that this behaviour causes is the example on the linked issue. If we access a method with argument types that are not being inferred by Substitute (Substitute infers the last overload - typescript behaviour), we lose Substitute's custom types and therefore typescript would not compile.

By applying this workaround we'll support up to five overloads to a function. This should cover most of the cases (or so I would like to believe). One case that won't be solved is the knex issue -> https://github.com/ffMathy/FluffySpoon.JavaScript.Testing.Faking/issues/82. Knex has like 14 or 15 overloads, and I don't think adding mannually 15 overloads is the way to go -> I would prefer a solution from the typescript engine.

