### PR TITLE
✨Implement configure method - Support to update the behaviour of a mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ],
     "scripts": {
         "prepack": "npm i && tsc",
-        "test": "tsc && ava",
+        "test": "tsc --sourceMap && ava",
         "build": "tsc"
     },
     "dependencies": {},

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -17,10 +17,14 @@ export class Context {
     private _setState: ContextState;
     private _receivedState: ContextState;
 
+    private _configurationMode: boolean;
+
     constructor() {
         this._initialState = new InitialState();
         this._setState = this._initialState;
         this._getState = this._initialState;
+
+        this._configurationMode = false;
 
         this._proxy = new Proxy(SubstituteBase, {
             apply: (_target, _this, args) => this.getStateApply(_target, _this, args),
@@ -98,6 +102,18 @@ export class Context {
         }
 
         return this._getState.get(this, property);
+    }
+
+    public enableConfigurationMode(): void {
+        this._configurationMode = true;
+    }
+
+    public disableConfigurationMode(): void {
+        this._configurationMode = false;
+    }
+
+    public isConfigurationMode(): boolean {
+        return this._configurationMode;
     }
 
     public get proxy() {

--- a/src/Transformations.ts
+++ b/src/Transformations.ts
@@ -70,6 +70,7 @@ export type ObjectSubstitute<T extends Object, K extends Object = T> = ObjectSub
     received(amount?: number): TerminatingObject<K>;
     didNotReceive(): TerminatingObject<K>;
     mimick(instance: T): void;
+    configure(): ObjectSubstituteTransformation<T>;
 }
 
 type TerminatingFunction<TArguments extends any[]> = ((...args: TArguments) => void) & ((arg: AllArguments<TArguments>) => void)

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -15,6 +15,7 @@ export enum SubstituteMethods {
     received = 'received',
     didNotReceive = 'didNotReceive',
     mimicks = 'mimicks',
+    configure = 'configure',
     throws = 'throws',
     returns = 'returns',
     resolves = 'resolves',

--- a/src/states/GetPropertyState.ts
+++ b/src/states/GetPropertyState.ts
@@ -1,7 +1,8 @@
 import { ContextState, PropertyKey } from './ContextState';
 import { Context } from '../Context';
-import { PropertyType, SubstituteMethods, Call, areArgumentArraysEqual } from '../Utilities';
+import { PropertyType, SubstituteMethods, Call, areArgumentArraysEqual, areArgumentsEqual } from '../Utilities';
 import { SubstituteException } from '../SubstituteBase';
+import { Argument, AllArguments } from '../Arguments';
 
 interface SubstituteMock {
     arguments: Call
@@ -9,8 +10,17 @@ interface SubstituteMock {
     substituteType: SubstituteMethods
 }
 
+interface ClassifiedSubstituteMocks {
+    'only-primitives': SubstituteMock[]
+    'with-single-argument': SubstituteMock[]
+    'all-argument': SubstituteMock[]
+
+}
+
+type ArgClassification = 'only-primitives' | 'with-single-argument' | 'all-argument'
+
 export class GetPropertyState implements ContextState {
-    private _mocks: SubstituteMock[];
+    private _mocks: ClassifiedSubstituteMocks;
     private _recordedCalls: Call[];
     private _isFunctionState: boolean;
     private _lastArgs?: Call;
@@ -28,7 +38,11 @@ export class GetPropertyState implements ContextState {
     }
 
     constructor(private _property: PropertyKey) {
-        this._mocks = [];
+        this._mocks = {
+            'only-primitives': [],
+            'with-single-argument': [],
+            'all-argument': []
+        };
         this._recordedCalls = [];
         this._isFunctionState = false;
     }
@@ -36,6 +50,14 @@ export class GetPropertyState implements ContextState {
     private getCallCount(args: Call): number {
         const callFilter = (recordedCall: Call): boolean => areArgumentArraysEqual(recordedCall, args);
         return this._recordedCalls.filter(callFilter).length;
+    }
+
+    private findSubstituteMock(argsToMatch: Call): SubstituteMock | undefined {
+        const findFilter = (args: Call) => (mock: SubstituteMock) => areArgumentArraysEqual(mock.arguments, args);
+        return this._mocks['only-primitives'].find(findFilter(argsToMatch)) ??
+            this._mocks['with-single-argument'].find(findFilter(argsToMatch)) ??
+            this._mocks['all-argument'].find(findFilter(argsToMatch));
+
     }
 
     private applySubstituteMethodLogic(substituteMethod: SubstituteMethods, mockValue: any, args?: Call) {
@@ -57,9 +79,10 @@ export class GetPropertyState implements ContextState {
 
     private processProperty(context: Context, args: any[], propertyType: PropertyType) {
         const hasExpectations = context.initialState.hasExpectations;
-        if (!hasExpectations) {
+        if (!hasExpectations && !context.isConfigurationMode()) {
             this._recordedCalls.push(args);
-            const foundSubstitute = this._mocks.find(mock => areArgumentArraysEqual(mock.arguments, args));
+
+            const foundSubstitute = this.findSubstituteMock(args)
             if (foundSubstitute !== void 0) {
                 const mockValue = foundSubstitute.mockValues.length > 1 ?
                     foundSubstitute.mockValues.shift() :
@@ -98,30 +121,76 @@ export class GetPropertyState implements ContextState {
             property === SubstituteMethods.rejects;
     }
 
-    private sanitizeSubstituteMockInputs(mockInputs: Call): Call {
+    private sanitizeSubstituteMockValues(mockInputs: Call): Call {
         if (mockInputs.length === 0) return [undefined];
         return mockInputs.length > 1 ?
             [...mockInputs, undefined] :
             [...mockInputs];
     }
 
+    private classifyArguments(args: Call): ArgClassification {
+        const allPrimitives = args.every(arg => !(arg instanceof Argument || arg instanceof AllArguments));
+        if (allPrimitives)
+            return 'only-primitives';
+        const hasSingleArgument = args.some(arg => arg instanceof Argument);
+        if (hasSingleArgument)
+            return 'with-single-argument';
+        return 'all-argument';
+    }
+
+    private calculateMockPosition(mocks: SubstituteMock[], argsType: ArgClassification, args: Call): -1 | number {
+        if (argsType === 'all-argument')
+            return 0;
+        if (argsType === 'only-primitives')
+            return mocks.findIndex(mock => areArgumentArraysEqual(mock.arguments, args));
+
+        return mocks.findIndex((mock) => {
+            const mockArguments = mock.arguments
+
+            for (let i = 0; i < Math.max(mockArguments.length, args.length); i++) {
+                const currentMockArgument: Argument<any> | unknown = mockArguments[i]
+                const currentArgument: Argument<any> | unknown = args[i]
+
+                if (currentMockArgument instanceof Argument && currentArgument instanceof Argument) {
+                    if (currentMockArgument.toString() !== currentArgument.toString()) return false;
+                    continue;
+                }
+
+                if (currentMockArgument instanceof Argument || currentArgument instanceof Argument)
+                    return false;
+
+                if (!areArgumentsEqual(currentMockArgument, currentArgument)) return false;
+            }
+
+            return true;
+        })
+    }
+
     get(context: Context, property: PropertyKey) {
         if (property === 'then') return void 0;
 
         if (this.isSubstituteMethod(property)) {
-            return (...inputs: Call) => {
-                const mockInputs = this.sanitizeSubstituteMockInputs(inputs);
+            return (...values: Call) => {
                 const args = this._isFunctionState ? this._lastArgs : [];
                 if (args === void 0)
                     throw SubstituteException.generic('Eh, there\'s a bug, no args recorded :/');
+                const argsType = this.classifyArguments(args)
 
-                this._mocks.push({
-                    arguments: args,
-                    mockValues: mockInputs,
-                    substituteType: property
-                });
+                const mockValues = this.sanitizeSubstituteMockValues(values);
+                const substituteMock = {
+                    arguments: argsType === 'all-argument' ? [new AllArguments()] : args,
+                    substituteType: property,
+                    mockValues
+                };
+
+                const mockPosition = this.calculateMockPosition(this._mocks[argsType], argsType, args);
+                if (mockPosition < 0)
+                    this._mocks[argsType].push(substituteMock);
+                else
+                    this._mocks[argsType][mockPosition] = substituteMock;
 
                 this._recordedCalls.pop();
+                context.disableConfigurationMode();
                 context.state = context.initialState;
             }
         }

--- a/src/states/InitialState.ts
+++ b/src/states/InitialState.ts
@@ -109,6 +109,11 @@ export class InitialState implements ContextState {
                     this._expectedCount = 0;
                     return context.receivedProxy;
                 };
+            case SubstituteMethods.configure:
+                return () => {
+                    context.enableConfigurationMode();
+                    return context.rootProxy;
+                }
             default:
                 return this.handleGet(context, property);
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,6 @@
         "moduleResolution": "node",
         "baseUrl": ".",
         "declaration": true,
-        "sourceMap": true,
-        "inlineSources": true,
         "outDir": "./dist",
         "strict": true,
         "strictNullChecks": false,


### PR DESCRIPTION
Fixes #46 🎉 

Still WIP, as I need to add tests to verify it works as intended, but basic functionality is there

With this implementation, the match order is slightly changing. When looking at the current readme it says:
> The order of argument matchers matters. The first matcher that matches will always be used

This will not be enterly true from now on. The matches are now divided into three groups that have different priorities, depending on the arguments. The groups and priorities are defined as the following:
1. Arguments with primitives only group - `calc.add(1, 2)`
2. Arguments with at least 1 Argument instance - `calc.add(Arg.any(), Arg.is(x => x > 0))`
3. Arguments replaced by Arg.all - `calc.add(Arg.all())`

Inside these tree groups, the current match order is preserved (first match that gets defined, is the first one to be used if matched).
This means that now it's possible to first define a generic / default match, followed by a specific one:
```typescript
calculator.add(Arg.all()).mimicks((a, b) => a + b)
calculator.configure().add(1, 1).returns(11)

console.log(calculator.add(90, 10)) // 100
console.log(calculator.add(1, 1)) // 11
```
Also reassigning the same match to different values
```typescript
calculator.add(1, 1).returns(2)
console.log(calculator.add(1, 1)) // 2

calculator.configure().add(1, 1).returns(0)
console.log(calculator.add(1, 1)) // 0

// even the method can be modified
calculator.configure().add(1, 1).throws(new Error('Change the number!'))
calculator.add(1, 1) // Error: Change the number!
```

##### TODO
- Find a less common name for the method `configure`
- Add tests
- Documentation