### PR TITLE
Add node 14 support and update Github Action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: install dependencies
       run: npm ci
-    - if: matrix.node-version === '8.x' # yargs on ava needs at least node 10 as engine
+    - if: matrix.node-version == '8.x' # yargs on ava needs at least node 10 as engine
       name: downgrade ava (node 8 only)
       run: npm i -D ava@3.12.1
     - name: build and test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,17 +9,21 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: ['8.x', '10.x', '12.x', '14.x']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install, build, and test
+    - name: install dependencies
+      run: npm ci
+    - if: matrix.node-version === '8.x' # yargs on ava needs at least node 10 as engine
+      name: downgrade ava (node 8 only)
+      run: npm i -D ava@3.12.1
+    - name: build and test:
       run: |
-        npm install
         npm run build --if-present
         npm test
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,7 +22,7 @@ jobs:
     - if: matrix.node-version === '8.x' # yargs on ava needs at least node 10 as engine
       name: downgrade ava (node 8 only)
       run: npm i -D ava@3.12.1
-    - name: build and test:
+    - name: build and test
       run: |
         npm run build --if-present
         npm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['8.x', '10.x', '12.x', '14.x']
+        node-version: ['10.x', '12.x', '14.x']
 
     steps:
     - uses: actions/checkout@v2
@@ -17,13 +17,9 @@ jobs:
       uses: actions/setup-node@v2-beta
       with:
         node-version: ${{ matrix.node-version }}
-    - name: install dependencies
-      run: npm ci
-    - if: matrix.node-version == '8.x' # yargs on ava needs at least node 10 as engine
-      name: downgrade ava (node 8 only)
-      run: npm i -D ava@3.12.1
-    - name: build and test
-      run: |
+    - name: install dependencies, build and test
+    run: |
+        npm ci
         npm run build --if-present
         npm test
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v2-beta
       with:
         node-version: ${{ matrix.node-version }}
     - name: install dependencies

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: install dependencies, build and test
-    run: |
+      run: |
         npm ci
         npm run build --if-present
         npm test

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "url": "https://github.com/ffMathy/FluffySpoon.JavaScript.Testing.Faking/issues"
     },
     "engines": {
-        "node": ">=8"
+        "node": ">=10"
     },
     "main": "dist/src/index.js",
     "typings": "./dist/src/index.d.ts",

--- a/spec/returns.spec.ts
+++ b/spec/returns.spec.ts
@@ -1,6 +1,8 @@
 import test from 'ava';
-import { Substitute, Arg } from '../src';
 import { inspect } from 'util'
+
+import { Substitute, Arg } from '../src';
+import { getCorrectConstructorDescriptor } from './util/compatibility';
 
 interface Calculator {
   add(a: number, b: number): number;
@@ -28,7 +30,7 @@ test('returns a primitive value for method with specific arguments', t => {
 
   t.is(calculator.add(1, 1), 2);
   t.is(calculator.add(1, 1), 2);
-  t.is(inspect(noResult.constructor), '[Function: SubstituteJS]');
+  t.is(inspect(noResult.constructor), `[${getCorrectConstructorDescriptor()} SubstituteJS]`);
 });
 
 test('returns a primitive value for method with specific arguments where the last argument is optional', t => {
@@ -46,8 +48,8 @@ test('returns a primitive value for method with specific arguments where the las
   const noResult = calculator.multiply(2, 2);
   const noResult2 = calculator.multiply(0);
 
-  t.is(inspect(noResult.constructor), '[Function: SubstituteJS]');
-  t.is(inspect(noResult2.constructor), '[Function: SubstituteJS]');
+  t.is(inspect(noResult.constructor), `[${getCorrectConstructorDescriptor()} SubstituteJS]`);
+  t.is(inspect(noResult2.constructor), `[${getCorrectConstructorDescriptor()} SubstituteJS]`);
 });
 
 test('returns a primitive value for method with specific and conditional arguments', t => {
@@ -97,7 +99,7 @@ test('returns a promise for method with specific arguments', async t => {
   const noResult = calculator.heavyOperation(1, 1, 1);
 
   t.is(result, true);
-  t.is(inspect(noResult.constructor), '[Function: SubstituteJS]');
+  t.is(inspect(noResult.constructor), `[${getCorrectConstructorDescriptor()} SubstituteJS]`);
 });
 
 test('returns a promise for method with specific and conditional arguments', async t => {
@@ -151,7 +153,7 @@ test('returns a primitive value on a property', t => {
 
   t.is(calculator.isEnabled, true);
   t.is(calculator.isEnabled, true);
-  t.is(inspect(noResult.constructor), '[Function: SubstituteJS]');
+  t.is(inspect(noResult.constructor), `[${getCorrectConstructorDescriptor()} SubstituteJS]`);
 });
 
 test('returns a promise on a property', async t => {

--- a/spec/util/compatibility.ts
+++ b/spec/util/compatibility.ts
@@ -1,0 +1,6 @@
+export const getCorrectConstructorDescriptor = () => {
+  const nodeVersionLowerThan12 = Number(process.versions.node.split('.')[0]) < 12;
+  return nodeVersionLowerThan12 ?
+    'Function:' :
+    'class';
+};

--- a/src/SubstituteBase.ts
+++ b/src/SubstituteBase.ts
@@ -10,30 +10,30 @@ export class SubstituteJS {
     return typeof this._lastRegisteredSubstituteJSMethodOrProperty === 'undefined' ? 'root' : this._lastRegisteredSubstituteJSMethodOrProperty;
   }
   [Symbol.toPrimitive]() {
-    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+    return `[class ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
   }
   [Symbol.toStringTag]() {
-    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+    return `[class ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
   }
   [Symbol.iterator]() {
-    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+    return `[class ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
   }
   [inspect.custom]() {
-    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+    return `[class ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
   }
   valueOf() {
-    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+    return `[class ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
   }
   $$typeof() {
-    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+    return `[class ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
   }
   toString() {
-    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+    return `[class ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
   }
   inspect() {
-    return `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+    return `[class ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
   }
-  length = `[Function: ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
+  length = `[class ${this.constructor.name}] -> ${this.lastRegisteredSubstituteJSMethodOrProperty}`;
 }
 
 enum SubstituteExceptionTypes {


### PR DESCRIPTION
For some reason, locally I can't run the tests when using node 8 - It breaks as ava uses new syntax.
We should really really consider dropping oficial node 8 support.
As long as we don't add the strict version flag in the package.json, people on node 8 will be able to install the library without troubles